### PR TITLE
Update BigQuery alert templates

### DIFF
--- a/alerts/google-bigquery/background-metadata-cache-slot-usage.v2.json
+++ b/alerts/google-bigquery/background-metadata-cache-slot-usage.v2.json
@@ -1,0 +1,22 @@
+{
+  "displayName": "Slot Usage - Background Metadata Cache Slot Usage Too High",
+  "documentation": {
+    "content": "This alert fires when the slot usage of a background metadata cache job type reservation exceeds 95% of the allocated slots.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Slot Usage - Background Metadata Cache Slot Usage",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "3600s",
+        "query": "max by (location,reservation) (label_replace(avg_over_time(bigquery_googleapis_com:slots_allocated{monitored_resource =\"bigquery_project\", job_type=\"background_metadata_cache\"}[1h]), \"reservation\", \"$1\", \"reservation\", \".*/.*/(.*)\" )) /  on(reservation, location) group_left max by (location, reservation)(avg_over_time( bigquery_googleapis_com:slots_assigned{monitored_resource = \"bigquery_project\", job_type=\"BACKGROUND\"}[1h]))  > 0.95"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}

--- a/alerts/google-bigquery/metadata.yaml
+++ b/alerts/google-bigquery/metadata.yaml
@@ -3,7 +3,12 @@ alert_policy_templates:
   id: background-metadata-cache-slot-usage
   display_name: Background Metadata Cache Slot Usage
   description: "Alert if slot usage of background metadata cache reservation types is too high"
-  version: 1
+  version: 2
   related_integrations:
     - id: bigquery
       platform: GCP
+-
+  id: single-reservation-slot-usage
+  display_name: ${FULL_RESERVATION_ID} Slot Usage Too High
+  description: "Alert if slot usage of the ${FULL_RESERVATION_ID} reservation is too high"
+  version: 1

--- a/alerts/google-bigquery/single-reservation-slot-usage.v1.json
+++ b/alerts/google-bigquery/single-reservation-slot-usage.v1.json
@@ -1,0 +1,22 @@
+{
+  "displayName": "Slot Usage - Reservation ${FULL_RESERVATION_ID} Slot Usage Too High",
+  "documentation": {
+    "content": "This alert fires when the slot usage of reservation ${FULL_RESERVATION_ID} exceeds 95% of the assigned slots.",
+    "mimeType": "text/markdown"
+  },
+  "userLabels": {},
+  "conditions": [
+    {
+      "displayName": "Slot Usage - Reservation ${FULL_RESERVATION_ID} Slot Usage Too High",
+      "conditionPrometheusQueryLanguage": {
+        "duration": "3600s",
+        "query": "max by (location) (label_replace(avg_over_time(bigquery_googleapis_com:slots_allocated{monitored_resource =\"bigquery_project\", reservation=~\"projects/.*/${RESERVATION_NAME}\"}[1h]), \"reservation\", \"$1\", \"reservation\", \".*/.*/(.*)\" )) / ignoring(reservation, job_type) max by (location)(avg_over_time(bigquery_googleapis_com:slots_assigned{monitored_resource = \"bigquery_project\", reservation=\"${RESERVATION_NAME}\"}[1h])) > 0.95"
+      }
+    }
+  ],
+  "alertStrategy": {
+    "autoClose": "604800s"
+  },
+  "combiner": "OR",
+  "enabled": true
+}


### PR DESCRIPTION
Update background-metadata-cache-slot-usage alert and add new single reservation alert

Update the background-metadata-cache-slot-usage alert to be a PromQL query that uses a dynamic threshold based on the number of assigned slots to that reservation. This means this alert will no longer take a static threshold. 

Also, add a new alert that targets a single reservation. This will be used on the capacity management page to directly generate an alert from a chosen reservation.